### PR TITLE
avoid visibility issues on SunOS on either gcc or studio

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -40,10 +40,12 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * see http://gcc.gnu.org/onlinedocs/gcc-3.3.5/gcc/Function-Attributes.html#Function-Attributes
  * see http://www.nedprod.com/programs/gccvisibility.html
  */
-#if defined __GNUC__ && (! defined (__sun)) && (__GNUC__ >= 4 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3))
+#if defined(__GNUC__) && \
+	(__GNUC__ >= 4 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3)) || \
+	defined(__SUNPRO_C) && __SUNPRO_C >= 0x590
 #define INTERNAL __attribute__ ((visibility("hidden")))
 #define PCSC_API __attribute__ ((visibility("default")))
-#elif (! defined __GNUC__ ) && defined (__sun)
+#elif defined(__SUNPRO_C) && __SUNPRO_C >= 0x550
 /* http://wikis.sun.com/display/SunStudio/Macros+for+Shared+Library+Symbol+Visibility */
 #define INTERNAL __hidden
 #define PCSC_API __global


### PR DESCRIPTION
by using a guard stipulating minimum versions for each compiler
needed to support __attribute__((visibility("hidden")) or equivalent