### PR TITLE
Avoid dividing by zero

### DIFF
--- a/src/simclist.c
+++ b/src/simclist.c
@@ -449,7 +449,10 @@ static inline struct list_entry_s *list_findpos(const list_t *restrict l, int po
     /* accept 1 slot overflow for fetching head and tail sentinels */
     if (posstart < -1 || posstart > (int)l->numels) return NULL;
 
-    x = (float)(posstart+1) / l->numels;
+    if( l->numels != 0 )
+        x = (float)(posstart+1) / l->numels;
+    else
+        x = 1;
     if (x <= 0.25) {
         /* first quarter: get to posstart from head */
         for (i = -1, ptr = l->head_sentinel; i < posstart; ptr = ptr->next, i++);
@@ -1580,4 +1583,3 @@ static int list_attrOk(const list_t *restrict l) {
 }
 
 #endif
-


### PR DESCRIPTION
I ran into this issue when trying to use libpcsclite from a Free Pascal binding.

It was constantly crashing because of a division by zero when trying to establish the context.

I fixed this by asking the runtime to handle float division by zero but still, it is not documented that your library is based on float division by zero not throwing any exception and more importantly, this behavior is undefined.

This is a small change to avoid that division when `l->numels` is zero.