### PR TITLE
Add --disable-documentation option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,6 +144,12 @@ esac
 AC_DEFINE_UNQUOTED(PCSC_ARCH, "$PCSC_ARCH", [PC/SC target architecture])
 PCSCLITE_FEATURES="${PCSCLITE_FEATURES} $PCSC_ARCH $host"
 
+# --disable-documentation
+AC_ARG_ENABLE(documentation,
+	AS_HELP_STRING([--disable-documentation],[do not build documentation]),
+	[ enable_doc="${enableval}" ], [ enable_doc="yes" ] )
+AM_CONDITIONAL(ENABLE_DOC, test "$enable_doc" != "no")
+
 # See if socket() is found from libsocket
 AC_CHECK_LIB(socket, socket, [LIBS="$LIBS -lsocket"])
 
@@ -446,6 +452,7 @@ use libsystemd:         ${use_libsystemd}
 systemd unit directory: ${with_systemdsystemunitdir}
 serial config dir.:     ${confdir_exp}
 filter:                 ${use_filter}
+documentation:          ${enable_doc}
 
 PCSCLITE_FEATURES:      ${PCSCLITE_FEATURES}
 

--- a/src/spy/Makefile.am
+++ b/src/spy/Makefile.am
@@ -6,6 +6,7 @@ dist_bin_SCRIPTS = pcsc-spy
 libpcscspy_la_SOURCES = \
 	libpcscspy.c
 
+if ENABLE_DOC
 man_MANS = pcsc-spy.1
 
 pcsc-spy.1: pcsc-spy.pod
@@ -13,6 +14,7 @@ pcsc-spy.1: pcsc-spy.pod
 		--center="PC/SC lite" \
 		--release="$(PACKAGE_NAME) $(PACKAGE_VERSION)" \
 		$(srcdir)/pcsc-spy.pod > $@
+endif
 
 EXTRA_DIST = install_spy.sh uninstall_spy.sh pcsc-spy.pod
 CLEANFILES = pcsc-spy.1


### PR DESCRIPTION
This option allows the user to disable man pages which can be useful if
podman is not available

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>