### PR TITLE
configure.ac: explicitly add pthread cflags/libs in the libusb test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -270,8 +270,8 @@ if test "x$use_libusb" != xno ; then
 	saved_CPPFLAGS="$CPPFLAGS"
 	saved_LIBS="$LIBS"
 
-	CPPFLAGS="$CPPFLAGS $LIBUSB_CFLAGS"
-	LIBS="$LDFLAGS $LIBUSB_LIBS"
+	CPPFLAGS="$CPPFLAGS $LIBUSB_CFLAGS $PTHREAD_CFLAGS"
+	LIBS="$LDFLAGS $LIBUSB_LIBS $PTHREAD_LIBS"
 
 	AC_CHECK_HEADERS(libusb.h, [],
 		[ AC_MSG_ERROR([libusb.h not found, use ./configure LIBUSB_CFLAGS=...]) ])


### PR DESCRIPTION
If libusb-config does not exist, LIBUSB_CFLAGS and PTHREAD_CFLAGS will be
empty, and the test for libusb will be performed without additional flags.
However, when libusb needs threads, some extra flags are needed (depending
on the platform), like -pthreads, -lpthread, etc. Without these flags, the
test for libusb_init() will fail to link correctly, and pcsc-lite will fail
detecting libusb.

Signed-off-by: Thomas De Schampheleire <thomas.de.schampheleire@gmail.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/pcsc-lite/0001-pthread-needed-for-libusb.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>