### PR TITLE
configfile: Avoid memory leaks in case of realloc failure (cppcheck warning)

### DIFF
--- a/src/configfile.l
+++ b/src/configfile.l
@@ -216,9 +216,18 @@ int evaluatetoken(char *pcToken)
 		}
 		else
 		{
+			SerialReader *new_reader_list = NULL;
 			reader_list_size++;
-			reader_list = realloc(reader_list, reader_list_size *
+			new_reader_list = realloc(reader_list, reader_list_size *
 				sizeof(SerialReader));
+			if (new_reader_list == NULL) {
+				free(reader_list);
+			}
+			reader_list = new_reader_list;
+		}
+		if (reader_list == NULL) {
+			tok_error("No Memory");
+			return 1;
 		}
 
 		/* end marker */


### PR DESCRIPTION
The original patch was written by Bob Relyea for RHEL package, but I tweaked it a bit to make sure it builds without warnings.