### PR TITLE
hotplug_libusb: remove obsolete libhal scheme

### DIFF
--- a/src/hotplug_libusb.c
+++ b/src/hotplug_libusb.c
@@ -121,8 +121,7 @@ static struct _readerTracker
 
 static LONG HPAddHotPluggable(struct libusb_device *dev,
 	struct libusb_device_descriptor desc,
-	const char bus_device[], int interface,
-	struct _driverTracker *driver);
+	const char bus_device[], struct _driverTracker *driver);
 static LONG HPRemoveHotPluggable(int reader_index);
 
 static LONG HPReadBundleValues(void)
@@ -365,14 +364,8 @@ static void HPRescanUsbBus(void)
 
 					/* New reader found */
 					if (newreader)
-					{
-						if (config_desc->bNumInterfaces > 1)
-							HPAddHotPluggable(dev, desc, bus_device,
-								interface, &driverTracker[i]);
-							else
-							HPAddHotPluggable(dev, desc, bus_device,
-								-1, &driverTracker[i]);
-					}
+                                            HPAddHotPluggable(dev, desc, bus_device,
+                                                              &driverTracker[i]);
 				}
 			}
 		}
@@ -529,21 +522,15 @@ LONG HPStopHotPluggables(void)
 
 static LONG HPAddHotPluggable(struct libusb_device *dev,
 	struct libusb_device_descriptor desc,
-	const char bus_device[], int interface,
-	struct _driverTracker *driver)
+	const char bus_device[], struct _driverTracker *driver)
 {
 	int i;
 	char deviceName[MAX_DEVICENAME];
 
 	Log2(PCSC_LOG_INFO, "Adding USB device: %s", bus_device);
 
-	if (interface >= 0)
-		snprintf(deviceName, sizeof(deviceName), "usb:%04x/%04x:libhal:/org/freedesktop/Hal/devices/usb_device_%04x_%04x_serialnotneeded_if%d",
-			 desc.idVendor, desc.idProduct, desc.idVendor, desc.idProduct,
-			 interface);
-	else
-		snprintf(deviceName, sizeof(deviceName), "usb:%04x/%04x:libusb-1.0:%s",
-			desc.idVendor, desc.idProduct, bus_device);
+        snprintf(deviceName, sizeof(deviceName), "usb:%04x/%04x:libusb-1.0:%s",
+                 desc.idVendor, desc.idProduct, bus_device);
 
 	deviceName[sizeof(deviceName) -1] = '\0';
 


### PR DESCRIPTION
libhal has been deprecated long ago and CCID does not support its device
name scheme anymore.

--

I have a dual interface reader (HID's OMNIKEY 5422).
When I plug it on a Linux machine I can access both interfaces.
When I plug it on a FreeBSD machine I can only access one of them (the contact-less one).

Debugging the PCSC Daemon, revealed the problem being in "src/hotplug_libusb.c"'s `HPAddHotPluggable()` function: when a single interface reader in plugged, a "libusb-1.0" device name scheme will be used when invoking driver's `IFDHCreateChannelByName()`, whereas, if a multi-interface reader is plugged, a "libhal" scheme is used instead.
But CCID (the driver I use for OMNIKEY 5422), does not know how to fully parse a "libhal" device name, it can only parse the "usb:XXXX/YYYY:" part, so the interface number is lost.

There are two possible solution to this issue:

1. prevent the PCSC Daemon from building "libhal" device names
2. add support in CCID to fully parse a "libhal" device name

Although the second solution is more conservative as it would prevent any driver relying on a "libhal" device name scheme from breaking, I chose to implement the first solution for the following reasons:

* if I read correctly the "Changelog" file, support for libhal has been deprecated since 2011
* it looks like support for the "libhal" scheme was added with commit 36fc3a6 because the "libusb" scheme, as implemented in the CCID driver, lacked support for specifying the interface number -- this is no more a problem as commit 8c57dcc (of the CCID project) added it
* support for the "libhal" scheme was removed from CCID with commit e468eef, so I guess there would be no point in adding it again

What do you think?