### PR TITLE
readerfactory: Make sure a freed Reader Context is not accessed

### DIFF
--- a/src/readerfactory.c
+++ b/src/readerfactory.c
@@ -599,7 +599,7 @@ LONG RFRemoveReader(const char *readerName, int port)
 
 	for (i = 0; i < PCSCLITE_MAX_READERS_CONTEXTS; i++)
 	{
-		if (sReadersContexts[i]->vHandle != 0)
+		if (sReadersContexts[i] && (sReadersContexts[i]->vHandle != 0))
 		{
 			strncpy(lpcStripReader,
 				sReadersContexts[i]->readerState->readerName,
@@ -1381,6 +1381,8 @@ void RFCleanupReaders(void)
 				Log2(PCSC_LOG_ERROR, "RFRemoveReader error: 0x%08lX", rv);
 
 			free(sReadersContexts[i]);
+
+			sReadersContexts[i] = NULL;
 		}
 	}
 


### PR DESCRIPTION
When multiple readers are instanciated on the computer, we have
multiple `READER_CONTEXT`.
The first removal (likely) frees the first READER_CONTEXT instance.
On the removal of the second instance, `RFRemoveReader()` goes
through each `READER_CONTEXT` instance including the first instance
that has been freed.

Valgrind shows the error:

```
00000665 [120043264] pcscdaemon.c:227:signal_thread() Preparing for suicide
01001380 [67533568] readerfactory.c:1361:RFCleanupReaders() entering cleaning function
00000334 [67533568] readerfactory.c:1370:RFCleanupReaders() Stopping reader: First PCD 00 00
00002433 [67533568] readerfactory.c:614:RFRemoveReader() UnrefReader() count was: 1
00000768 [67533568] eventhandler.c:175:EHDestroyEventHandler() Stomping thread.
00000254 [67533568] ifd-vpcd.c:290:IFDHGetCapabilities() unknown tag 4017
00000290 [67533568] ifd-vpcd.c:290:IFDHGetCapabilities() unknown tag 4018
00000273 [67533568] eventhandler.c:204:EHDestroyEventHandler() Waiting polling thread
00304949 [130553600] eventhandler.c:504:EHStatusHandlerThread() Die
00033452 [67533568] eventhandler.c:215:EHDestroyEventHandler() Thread stomped.
00000391 [67533568] readerfactory.c:1134:RFUnInitializeReader() Attempting shutdown of First PCD 00 00.
00004501 [67533568] readerfactory.c:614:RFRemoveReader() UnrefReader() count was: 1
00000057 [67533568] eventhandler.c:175:EHDestroyEventHandler() Stomping thread.
00000046 [67533568] ifd-vpcd.c:290:IFDHGetCapabilities() unknown tag 4017
00000044 [67533568] ifd-vpcd.c:290:IFDHGetCapabilities() unknown tag 4018
00000042 [67533568] eventhandler.c:204:EHDestroyEventHandler() Waiting polling thread
00394441 [138946304] eventhandler.c:504:EHStatusHandlerThread() Die
00001272 [67533568] eventhandler.c:215:EHDestroyEventHandler() Thread stomped.
00000200 [67533568] readerfactory.c:1134:RFUnInitializeReader() Attempting shutdown of First PCD 00 01.
00000838 [67533568] readerfactory.c:991:RFUnloadReader() Unloading reader driver.
00030272 [67533568] readerfactory.c:1370:RFCleanupReaders() Stopping reader: Second 00 00
==8630== Invalid read of size 8
==8630==    at 0x1116F3: RFRemoveReader (readerfactory.c:602)
==8630==    by 0x112A2B: RFCleanupReaders (readerfactory.c:1378)
==8630==    by 0x10BC8D: SVCServiceRunLoop (pcscdaemon.c:123)
==8630==    by 0x10BC8D: main (pcscdaemon.c:779)
==8630==  Address 0x667b7d8 is 280 bytes inside a block of size 440 free'd
==8630==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8630==    by 0x112A61: RFCleanupReaders (readerfactory.c:1383)
==8630==    by 0x10BC8D: SVCServiceRunLoop (pcscdaemon.c:123)
==8630==    by 0x10BC8D: main (pcscdaemon.c:779)
==8630==  Block was alloc'd at
==8630==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8630==    by 0x11025D: RFAllocateReaderSpace (readerfactory.c:142)
==8630==    by 0x10B758: main (pcscdaemon.c:637)
==8630==
00001158 [67533568] readerfactory.c:614:RFRemoveReader() UnrefReader() count was: 1
00000074 [67533568] eventhandler.c:175:EHDestroyEventHandler() Stomping thread.
```