### PR TITLE
Add missing includes

### DIFF
--- a/src/atrhandler.h
+++ b/src/atrhandler.h
@@ -39,6 +39,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __atrhandler_h__
 #define __atrhandler_h__
 
+#include "wintypes.h"
+
 	/*
 	 * Decodes the ATR
 	 */

--- a/src/configfile.h
+++ b/src/configfile.h
@@ -35,6 +35,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __configfile_h__
 #define __configfile_h__
 
+#include "readerfactory.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/dyn_generic.h
+++ b/src/dyn_generic.h
@@ -38,6 +38,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __dyn_generic_h__
 #define __dyn_generic_h__
 
+#include "wintypes.h"
+
 	LONG DYN_LoadLibrary(void **, char *);
 	LONG DYN_CloseLibrary(void **);
 	LONG DYN_GetAddress(void *, /*@out@*/ void **, const char *, int);

--- a/src/eventhandler.h
+++ b/src/eventhandler.h
@@ -41,6 +41,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdint.h>
 
+#include "pcsclite.h"
+#include "readerfactory.h"
+#include "wintypes.h"
+
 	/**
 	 * Define an exported public reader state structure so each
 	 * application gets instant notification of changes in state.

--- a/src/hotplug.h
+++ b/src/hotplug.h
@@ -38,6 +38,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __hotplug_h__
 #define __hotplug_h__
 
+#include "wintypes.h"
+
 #ifndef PCSCLITE_HP_DROPDIR
 #define PCSCLITE_HP_DROPDIR		"/usr/local/pcsc/drivers/"
 #endif

--- a/src/ifdwrapper.h
+++ b/src/ifdwrapper.h
@@ -39,6 +39,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __ifdwrapper_h__
 #define __ifdwrapper_h__
 
+#include "ifdhandler.h"
+#include "readerfactory.h"
+#include "wintypes.h"
+
 	RESPONSECODE IFDOpenIFD(READER_CONTEXT *);
 	RESPONSECODE IFDCloseIFD(READER_CONTEXT *);
 	RESPONSECODE IFDPowerICC(READER_CONTEXT *, DWORD, PUCHAR, /*@out@*/ PDWORD);

--- a/src/prothandler.h
+++ b/src/prothandler.h
@@ -38,6 +38,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __prothandler_h__
 #define __prothandler_h__
 
+#include "readerfactory.h"
+#include "wintypes.h"
+
 	DWORD PHSetProtocol(struct ReaderContext *, DWORD, UCHAR, UCHAR);
 
 #define SET_PROTOCOL_WRONG_ARGUMENT -1

--- a/src/winscard_msg.h
+++ b/src/winscard_msg.h
@@ -43,6 +43,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdint.h>
 
+#include "pcsclite.h"
+#include "wintypes.h"
+
 /** Major version of the current message protocol */
 #define PROTOCOL_VERSION_MAJOR 4
 /** Minor version of the current message protocol */

--- a/src/winscard_svc.h
+++ b/src/winscard_svc.h
@@ -41,6 +41,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __winscard_svc_h__
 #define __winscard_svc_h__
 
+#include <stdint.h>
+
+#include "wintypes.h"
+
 	LONG ContextsInitialize(int, int);
 	void ContextsDeinitialize(void);
 	LONG CreateContextThread(uint32_t *);


### PR DESCRIPTION
atrhandler.h:
* include wintypes.h for DWORD, etc.;

configfile.h:
* include readerfactory.h for SerialReader;

dyn_generic.h:
* include wintypes.h for LONG;

eventhandler.h:
* include pcsclite.h for MAX_READERNAME, etc.;
* include readerfactory.h for READER_CONTEXT;
* include wintypes.h for UCHAR, etc.;

hotplug.h:
* include wintypes.h for LONG, etc.;

ifdwrapper.h:
* include ifdhandler.h for SCARD_IO_HEADER, etc.;
* include readerfactory.h for READER_CONTEXT;
* include wintypes.h for LONG, etc.;

prothandler.h:
* include readerfactory.h for ReaderContext;
* include wintypes.h for DWORD, etc.;

winscard_msg.h:
* include pcsclite.h for MAX_READERNAME;
* include wintypes.h for LONG, etc.;

winscard_svc.h:
* include stdint.h for uint32_t;
* include wintypes.h for LONG.