### PR TITLE
No data races in EHStatusHandlerThread

### DIFF
--- a/src/readerfactory.h
+++ b/src/readerfactory.h
@@ -40,6 +40,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <inttypes.h>
 #include <pthread.h>
+#include <stdatomic.h>
 
 #include "ifdhandler.h"
 #include "pcscd.h"
@@ -123,9 +124,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		int version;			/**< IFD Handler version number */
 		int port;				/**< Port ID */
 		int slot;				/**< Current Reader Slot */
-		volatile SCARDHANDLE hLockId;	/**< Lock Id */
+		_Atomic SCARDHANDLE hLockId;	/**< Lock Id */
 		int LockCount;			/**< number of recursive locks */
-		int32_t contexts;		/**< Number of open contexts */
+		_Atomic int32_t contexts;		/**< Number of open contexts */
 		int * pFeeds;			/**< Number of shared client to lib */
 		int * pMutex;			/**< Number of client to mutex */
 		int powerState;			/**< auto power off state */
@@ -134,6 +135,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 		pthread_mutex_t reference_lock;	 /**< reference mutex */
 
 		struct pubReaderStatesList *readerState; /**< link to the reader state */
+		/**< the latest state as updated in the event handler thread. you fetch, you free */
+		struct pubReaderStatesList * _Atomic ehThreadReaderState;
 		/* we can't use READER_STATE * here since eventhandler.h can't be
 		 * included because of circular dependencies */
 	};


### PR DESCRIPTION
Problem:

The thread running `EHStatusHandlerThread` will race all the `rContext->readerState->fields` as well as the `powerState` and some other flags. These flags are both consumed and set by the thread running the ccid driver as well.

Solution:
Make the flow unidirectional*: the status thread will always set its own copy and "stash" a unique copy ready to be consumed by the driver thread. That copy is consumed and `rcontext->readerState` is updated in `RFCheckReaderState` and a few other functions in `readerfactory.c`. Whenever a copy is consumed it is also freed. Note that even though this adds dynamic allocation it's at most 2 instances of `READER_STATE`.

This PR uses the C11 `_Atomic` feature. I'm not very familiar with all the compilers pcsc is built with, but if you deem this to be incompatible, please review the overall approach and I can `#ifdef` and do some mutexes for platforms which do not provide `_Atomic`

* the flow is unidirectional except for the readerName which is logged at the beginning of the status thread. That should not be a problem since the name is set from the driver thread before the status thread is spawned.