### PR TITLE
Fix variable substitution in systemd units

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -461,8 +461,6 @@ doc/pcscd.8
 doc/reader.conf.5
 doc/example/Makefile
 etc/Makefile
-etc/pcscd.service
-etc/pcscd.socket
 src/Makefile
 src/libpcsclite.pc
 src/pcscd.h

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,9 +1,13 @@
 if HAVE_SYSTEMD
-SCRIPT_IN_FILES = \
-	pcscd.service.in \
-	pcscd.socket.in
-
 systemdsystemunit_DATA = \
 	pcscd.service \
 	pcscd.socket
+
+edit = sed \
+	-e 's|@sysconfdir[@]|$(sysconfdir)|g' \
+	-e 's|@sbindir_exp[@]|$(sbindir_exp)|g' \
+	-e 's|@ipcdir[@]|$(ipcdir)|g'
+
+$(systemdsystemunit_DATA): % : %.in
+	$(edit) $< >$@
 endif


### PR DESCRIPTION
This change fixes the issue I reported in http://lists.infradead.org/pipermail/pcsclite-muscle/2021-December/001215.html (before discovering that this project was available on GitHub).

It addresses the critical part where an invalid file was generated as a result. However, there are more files that have variable substitution performed, arguably, in a pretty fragile way, which may result in similar issues occurring in other files after some future changes.