### PR TITLE
Use quoted includes in headers.

### DIFF
--- a/src/PCSC/pcsclite.h.in
+++ b/src/PCSC/pcsclite.h.in
@@ -42,7 +42,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __pcsclite_h__
 #define __pcsclite_h__
 
-#include <wintypes.h>
+#include "wintypes.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/src/PCSC/winscard.h
+++ b/src/PCSC/winscard.h
@@ -38,7 +38,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __winscard_h__
 #define __winscard_h__
 
-#include <pcsclite.h>
+#include "pcsclite.h"
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
Compilers like Clang issue a compile error when using angle brackets for
these include files. This due to the location of the header files.
On Arch Linux (and Windows), the include is done using <PCSC/winscard.h>.

When now using angle brackets in winscard.h, the compiler can't find
pcsclite.h because it is not in the default include path, it is in
<PCSC/pcsclite.h>, not <pcsclite.h>.

When using quotes, the compiler searches in the directory of the
including file first, where it can find the header.

The same goes for wintypes.h, included in pcsclite.h.

This causes me headaches when trying to compile for Arch in an docker file using Clang.
I always have to patch those two headers. :)