### PR TITLE
pcscdaemon: Fix possible unitialized variable

### DIFF
--- a/src/pcscdaemon.c
+++ b/src/pcscdaemon.c
@@ -107,7 +107,7 @@ static void SVCServiceRunLoop(void)
 {
 	int rsp;
 	LONG rv;
-	uint32_t dwClientID;	/* Connection ID used to reference the Client */
+	uint32_t dwClientID = 1;	/* Connection ID used to reference the Client */
 
 	while (TRUE)
 	{


### PR DESCRIPTION
The gcc reports errors like these:

```
pcscdaemon.c: In function 'main':
winscard_msg_srv.c:259:25: error: 'dwClientID' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  259 |                         Log2(PCSC_LOG_ERROR,
      |                         ^
pcscdaemon.c:110:18: note: 'dwClientID' was declared here
  110 |         uint32_t dwClientID;    /* Connection ID used to reference the Client */
      |                  ^
```

Fixes https://github.com/LudovicRousseau/PCSC/issues/126