### PR TITLE
Fix shutdown memory leak of sReadersContexts

### DIFF
--- a/src/readerfactory.c
+++ b/src/readerfactory.c
@@ -1396,11 +1396,10 @@ void RFCleanupReaders(void)
 
 			if (rv != SCARD_S_SUCCESS)
 				Log2(PCSC_LOG_ERROR, "RFRemoveReader error: 0x%08lX", rv);
-
-			free(sReadersContexts[i]);
-
-			sReadersContexts[i] = NULL;
 		}
+
+		free(sReadersContexts[i]);
+		sReadersContexts[i] = NULL;
 	}
 
 #ifdef USE_SERIAL


### PR DESCRIPTION
RFCleanupReaders() should always free memory of sReadersContexts, not
only when the reader was active.

This was only a minor, shutdown-only, issue.