### PR TITLE
Fix libusb_device list leak on shutdown

### DIFF
--- a/src/hotplug_libusb.c
+++ b/src/hotplug_libusb.c
@@ -443,6 +443,9 @@ static void HPRescanUsbBus(void)
 			HPRemoveHotPluggable(i);
 	}
 
+	/* free the libusb allocated list & devices */
+	libusb_free_device_list(devs, 1);
+
 	if (AraKiriHotPlug)
 	{
 		int retval;
@@ -460,9 +463,6 @@ static void HPRescanUsbBus(void)
 		Log1(PCSC_LOG_INFO, "Hotplug stopped");
 		pthread_exit(&retval);
 	}
-
-	/* free the libusb allocated list & devices */
-	libusb_free_device_list(devs, 1);
 }
 
 static void * HPEstablishUSBNotifications(int pipefd[2])


### PR DESCRIPTION
Call libusb_free_device_list() before exiting the hotplug thread in
hotplug_libusb.c.