### PR TITLE
Make sure AraKiriHotPlug false on libusb startup

### DIFF
--- a/src/hotplug_libusb.c
+++ b/src/hotplug_libusb.c
@@ -549,6 +549,7 @@ LONG HPSearchHotPluggables(void)
 {
 	int i;
 
+	AraKiriHotPlug = FALSE;
 	for (i=0; i<PCSCLITE_MAX_READERS_CONTEXTS; i++)
 	{
 		readerTracker[i].status = READER_ABSENT;


### PR DESCRIPTION
Reset the AraKiriHotPlug flag to false when starting libusb hotplug
search.

This is not needed on the initial process startup, because the flag is
initialized to false, but allows to implement unit tests that need to
restart the previously stopped threads within the memory of the same
process.