### PR TITLE
Add in the ability to dynamically adjust module path at run-time via system environmental exports

### DIFF
--- a/src/hotplug.h
+++ b/src/hotplug.h
@@ -57,5 +57,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	ULONG HPRegisterForHotplugEvents(void);
 	LONG HPStopHotPluggables(void);
 	void HPReCheckSerialReaders(void);
+	char * HPGetenv(const char *name);
 
 #endif

--- a/src/hotplug_macosx.c
+++ b/src/hotplug_macosx.c
@@ -90,6 +90,7 @@ static HPDeviceList sDeviceList = NULL;
 
 static int HPScan(void);
 static HPDriver *Drivers = NULL;
+static char * hpDirPath = PCSCLITE_HP_DROPDIR;
 
 /*
  * A callback to handle the asynchronous appearance of new devices that are
@@ -753,7 +754,12 @@ static void HPDeviceNotificationThread(void)
  */
 LONG HPSearchHotPluggables(void)
 {
-	Drivers = HPDriversGetFromDirectory(PCSCLITE_HP_DROPDIR);
+
+	hpDirPath = HPGetenv("PCSCLITE_HP_DROPDIR");
+	if(!hpDirPath)
+		hpDirPath = PCSCLITE_HP_DROPDIR;
+
+	Drivers = HPDriversGetFromDirectory(hpDirPath);
 
 	if (!Drivers)
 		return 1;


### PR DESCRIPTION
Add in the ability to dynamically adjust module path at run-time via system environmental exports

Background: While trying to integrate PKCS11+HSM into a build system (Yocto Project), we wanted the build system to be able to use the HSM directly. However, The Yocto Project creates a sandboxed environment for each package which uses pcsc-lite during compilation. This means that the pcsc-lite modules cannot be found from within these sandboxed directories, as their paths are non-determinable at compile time. OpenSSL appears to use OPENSSL_CONF for this sort of dynamic configuration, so I've followed their lead and incorporated a similar HPGetenv() method.