### PR TITLE
pcscd: allow configuring power-down and exit timeouts

### DIFF
--- a/doc/pcscd.8.in
+++ b/doc/pcscd.8.in
@@ -79,6 +79,10 @@ pcscd will quit after 60 seconds of inactivity after the release of
 the last PC/SC context. This is used when pcscd
 is started on demand by systemd.
 .TP
+.BR \-P ", " \-\-power\-down\-timeout " \fIt\fP"
+If auto power-down is enabled, power down inactive readers in \fIt\fP
+seconds (default: 5).
+.TP
 .BR \-S ", " \-\-reader\-name\-no\-serial
 Do not include the USB serial number in the reader name.
 .TP

--- a/doc/pcscd.8.in
+++ b/doc/pcscd.8.in
@@ -74,8 +74,9 @@ Ask pcscd to re-read the
 files to detect added or removed non-USB readers (serial or PCMCIA).
 .
 .TP
-.BR \-x ", " \-\-auto\-exit
-pcscd will quit after 60 seconds of inactivity after the release of
+.BR \-x ", " \-\-auto\-exit[=timeout]
+pcscd will quit after \fItimeout\fP seconds of inactivity (default: 60)
+after the release of
 the last PC/SC context. This is used when pcscd
 is started on demand by systemd.
 .TP

--- a/src/eventhandler.c
+++ b/src/eventhandler.c
@@ -458,7 +458,7 @@ static void * EHStatusHandlerThread(READER_CONTEXT * rContext)
 #ifndef DISABLE_ON_DEMAND_POWER_ON
 			if (POWER_STATE_POWERED == RFGetPowerState(rContext))
 				/* The card is powered but not yet used */
-				timeout = PCSCLITE_POWER_OFF_GRACE_PERIOD;
+				timeout = 1000 * PowerDownTimeout;
 			else
 				/* The card is already in use or not used at all */
 #endif

--- a/src/pcscd.h.in
+++ b/src/pcscd.h.in
@@ -36,7 +36,7 @@
 #ifndef __pcscd_h__
 #define __pcscd_h__
 
-#define TIME_BEFORE_SUICIDE 60
+#define TIME_BEFORE_SUICIDE_DEFAULT 60
 
 #define SCARD_RESET			0x0001	/**< Card was reset */
 #define SCARD_INSERTED			0x0002	/**< Card was inserted */

--- a/src/pcscd.h.in
+++ b/src/pcscd.h.in
@@ -67,7 +67,8 @@ enum
 };
 
 /** time to wait before powering down an unused card */
-#define PCSCLITE_POWER_OFF_GRACE_PERIOD 5*1000 /* 5 second */
+#define PCSCLITE_POWER_OFF_GRACE_PERIOD_DEFAULT 5 /* in seconds */
+extern int PowerDownTimeout;
 
 /** normal timeout for pthCardEvent driver function when
  * no card or card in use */

--- a/src/pcscdaemon.c
+++ b/src/pcscdaemon.c
@@ -74,6 +74,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 _Atomic bool AraKiri = false;
 static bool Init = true;
 bool AutoExit = false;
+int PowerDownTimeout = PCSCLITE_POWER_OFF_GRACE_PERIOD_DEFAULT;
 bool SocketActivated = false;
 static int ExitValue = EXIT_FAILURE;
 int HPForceReaderPolling = 0;
@@ -285,13 +286,14 @@ int main(int argc, char **argv)
 		{"max-card-handle-per-thread", 1, NULL, 's'},
 		{"max-card-handle-per-reader", 1, NULL, 'r'},
 		{"auto-exit", 0, NULL, 'x'},
+		{"power-down-timeout", 1, NULL, 'P'},
 		{"reader-name-no-serial", 0, NULL, 'S'},
 		{"reader-name-no-interface", 0, NULL, 'I'},
 		{"disable-polkit", 0, NULL, 1},
 		{NULL, 0, NULL, 0}
 	};
 #endif
-#define OPT_STRING "c:fTdhvaieCHt:r:s:xSI"
+#define OPT_STRING "c:fTdhvaieCHt:r:s:xP:SI"
 
 	setToForeground = false;
 	HotPlug = false;
@@ -415,6 +417,12 @@ int main(int argc, char **argv)
 				AutoExit = true;
 				Log2(PCSC_LOG_INFO, "Auto exit after %d seconds of inactivity",
 					TIME_BEFORE_SUICIDE);
+				break;
+
+			case 'P':
+				PowerDownTimeout = optarg ? atoi(optarg) : 0;
+				Log2(PCSC_LOG_INFO, "setting power down timeout to: %d",
+				     PowerDownTimeout);
 				break;
 
 			case 'S':
@@ -890,6 +898,7 @@ static void print_usage(char const * const progname)
 	printf("  -s, --max-card-handle-per-thread	maximum number of card handle per thread (default: %d)\n", PCSC_MAX_CONTEXT_CARD_HANDLES);
 	printf("  -r, --max-card-handle-per-reader	maximum number of card handle per reader (default: %d)\n", PCSC_MAX_READER_HANDLES);
 	printf("  -x, --auto-exit	pcscd will quit after %d seconds of inactivity\n", TIME_BEFORE_SUICIDE);
+	printf("  -P, --power-down-timeout	seconds to wait before powering down inactive reader\n");
 	printf("  -S, --reader-name-no-serial    do not include the USB serial number in the name\n");
 	printf("  -I, --reader-name-no-interface do not include the USB interface name in the name\n");
 	printf("  --disable-polkit	disable polkit support\n");
@@ -911,6 +920,7 @@ static void print_usage(char const * const progname)
 	printf("  -s    maximum number of card handle per thread\n");
 	printf("  -r    maximum number of card handle per reader\n");
 	printf("  -x	pcscd will quit after %d seconds of inactivity\n", TIME_BEFORE_SUICIDE);
+	printf("  -P	seconds to wait before powering down inactive reader\n");
 #endif
 }
 

--- a/src/pcscdaemon.c
+++ b/src/pcscdaemon.c
@@ -74,6 +74,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 _Atomic bool AraKiri = false;
 static bool Init = true;
 bool AutoExit = false;
+int TimeBeforeSuicide = TIME_BEFORE_SUICIDE_DEFAULT;
 int PowerDownTimeout = PCSCLITE_POWER_OFF_GRACE_PERIOD_DEFAULT;
 bool SocketActivated = false;
 static int ExitValue = EXIT_FAILURE;
@@ -285,7 +286,7 @@ int main(int argc, char **argv)
 		{"max-thread", 1, NULL, 't'},
 		{"max-card-handle-per-thread", 1, NULL, 's'},
 		{"max-card-handle-per-reader", 1, NULL, 'r'},
-		{"auto-exit", 0, NULL, 'x'},
+		{"auto-exit", optional_argument, NULL, 'x'},
 		{"power-down-timeout", 1, NULL, 'P'},
 		{"reader-name-no-serial", 0, NULL, 'S'},
 		{"reader-name-no-interface", 0, NULL, 'I'},
@@ -415,8 +416,11 @@ int main(int argc, char **argv)
 
 			case 'x':
 				AutoExit = true;
+				TimeBeforeSuicide = optarg ?
+					atoi(optarg) :
+					TIME_BEFORE_SUICIDE_DEFAULT;
 				Log2(PCSC_LOG_INFO, "Auto exit after %d seconds of inactivity",
-					TIME_BEFORE_SUICIDE);
+					TimeBeforeSuicide);
 				break;
 
 			case 'P':
@@ -800,8 +804,8 @@ int main(int argc, char **argv)
 	if (AutoExit)
 	{
 		Log2(PCSC_LOG_DEBUG, "Starting suicide alarm in %d seconds",
-			TIME_BEFORE_SUICIDE);
-		alarm(TIME_BEFORE_SUICIDE);
+			TimeBeforeSuicide);
+		alarm(TimeBeforeSuicide);
 	}
 
 	SVCServiceRunLoop();
@@ -897,7 +901,7 @@ static void print_usage(char const * const progname)
 	printf("  -t, --max-thread	maximum number of threads (default %d)\n", PCSC_MAX_CONTEXT_THREADS);
 	printf("  -s, --max-card-handle-per-thread	maximum number of card handle per thread (default: %d)\n", PCSC_MAX_CONTEXT_CARD_HANDLES);
 	printf("  -r, --max-card-handle-per-reader	maximum number of card handle per reader (default: %d)\n", PCSC_MAX_READER_HANDLES);
-	printf("  -x, --auto-exit	pcscd will quit after %d seconds of inactivity\n", TIME_BEFORE_SUICIDE);
+	printf("  -x, --auto-exit	pcscd will quit after %d seconds of inactivity\n", TIME_BEFORE_SUICIDE_DEFAULT);
 	printf("  -P, --power-down-timeout	seconds to wait before powering down inactive reader\n");
 	printf("  -S, --reader-name-no-serial    do not include the USB serial number in the name\n");
 	printf("  -I, --reader-name-no-interface do not include the USB interface name in the name\n");
@@ -919,7 +923,7 @@ static void print_usage(char const * const progname)
 	printf("  -t    maximum number of threads\n");
 	printf("  -s    maximum number of card handle per thread\n");
 	printf("  -r    maximum number of card handle per reader\n");
-	printf("  -x	pcscd will quit after %d seconds of inactivity\n", TIME_BEFORE_SUICIDE);
+	printf("  -x	pcscd will quit after %d seconds of inactivity\n", TIME_BEFORE_SUICIDE_DEFAULT);
 	printf("  -P	seconds to wait before powering down inactive reader\n");
 #endif
 }

--- a/src/winscard_svc.c
+++ b/src/winscard_svc.c
@@ -73,6 +73,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 extern bool AutoExit;
+extern int TimeBeforeSuicide;
 static int contextMaxThreadCounter = PCSC_MAX_CONTEXT_THREADS;
 static int contextMaxCardHandles = PCSC_MAX_CONTEXT_CARD_HANDLES;
 
@@ -1092,8 +1093,8 @@ static void MSGCleanupClient(SCONTEXT * threadContext)
 	if (AutoExit && (listSize < 1))
 	{
 		Log2(PCSC_LOG_DEBUG, "Starting suicide alarm in %d seconds",
-			TIME_BEFORE_SUICIDE);
-		alarm(TIME_BEFORE_SUICIDE);
+			TimeBeforeSuicide);
+		alarm(TimeBeforeSuicide);
 	}
 
 	return;


### PR DESCRIPTION
I've recently started using a yubikey PIV; the device is configured to require the PIN once per session. But since the tool I use it with (`age`) does not keep a long-running connection to `pcscd`, a "session" only lasts 5 seconds until the device is auto-powered off. Likewise, even if that timeout is bumped, then `pcscd` still auto-exits after 60.

The problem is discussed in more detail in https://github.com/str4d/age-plugin-yubikey/issues/144.

Here are two patches to allow the user to bump those two timeouts. I'm using it with on my Debian system by putting `PCSCD_ARGS="--auto-exit=86400 --power-down-timeout=86400"` into my `/etc/default/pcscd` file.

This certainly solves my problem. I'm not sure what the drawbacks might be, aside from presumably some extra power draw to keep the device powered. That's not a big deal for my use case, but it may mean that it's not a good general solution. Still, it seems like this is just giving users more run-time options (without having to rebuild the daemon themselves), which is probably a good thing.

