### PR TITLE
RFC: Stop depending on libsystemd for socket activation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,16 +137,6 @@ AC_CHECK_LIB(socket, socket, [LIBS="$LIBS -lsocket"])
 # check for mq_getattr()
 AC_CHECK_LIB(rt, mq_getattr, [LIBS="$LIBS -lrt"])
 
-# check for libsystemd
-AC_ARG_ENABLE(libsystemd,
-	AS_HELP_STRING([--disable-libsystemd], [do not use libsystemd]),
-	[ use_libsystemd="${enableval}" ], [ use_libsystemd="yes" ] )
-AS_IF([test "$use_libsystemd" != "no"],
-	[PKG_CHECK_MODULES(LIBSYSTEMD, libsystemd,,
-		[ AC_MSG_ERROR([install libsystemd-dev or use --disable-libsystemd]) ])
-	AC_DEFINE(USE_LIBSYSTEMD, 1, [Use libsystemd])
-	PCSCLITE_FEATURES="${PCSCLITE_FEATURES} libsystemd"])
-
 # --disable-serial
 AC_ARG_ENABLE(serial,
 	AS_HELP_STRING([--disable-serial], [do not use serial reader.conf files]),
@@ -415,7 +405,6 @@ ATR parsing messages:   ${debugatr}
 ipcdir:                 ${ipcdir}
 use serial:             ${use_serial}
 use usb:                ${use_usb}
-use libsystemd:         ${use_libsystemd}
 systemd unit directory: ${with_systemdsystemunitdir}
 serial config dir.:     ${confdir_exp}
 filter:                 ${use_filter}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,9 +76,9 @@ pcscd_SOURCES = \
 	winscard_svc.c \
 	winscard_svc.h
 pcscd_CFLAGS = $(CFLAGS) $(PTHREAD_CFLAGS) $(LIBUSB_CFLAGS) $(LIBUDEV_CFLAGS) \
-	$(POLKIT_CFLAGS) $(LIBSYSTEMD_CFLAGS) \
+	$(POLKIT_CFLAGS) \
 	-DPCSCD -DSIMCLIST_NO_DUMPRESTORE
-pcscd_LDFLAGS = $(LDFLAGS) $(LIBSYSTEMD_LIBS) -export-dynamic
+pcscd_LDFLAGS = $(LDFLAGS) -export-dynamic
 pcscd_LDADD = \
 	$(PTHREAD_LIBS) $(COREFOUNDATION) \
 	$(LIBUSB_LIBS) $(IOKIT) $(LIBUDEV_LIBS) \

--- a/src/pcscdaemon.c
+++ b/src/pcscdaemon.c
@@ -54,9 +54,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
 #endif
-#ifdef USE_LIBSYSTEMD
-#include <systemd/sd-daemon.h>
-#endif
 
 #include "misc.h"
 #include "pcsclite.h"
@@ -441,11 +438,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-#ifdef USE_LIBSYSTEMD
-	/*
-	 * Check if systemd passed us any file descriptors
-	 */
-	rv = sd_listen_fds(0);
+	rv = GetListenFdCount();
 	if (rv > 1)
 	{
 		Log1(PCSC_LOG_CRITICAL, "Too many file descriptors received");
@@ -456,12 +449,11 @@ int main(int argc, char **argv)
 		if (rv == 1)
 		{
 			SocketActivated = true;
-			Log1(PCSC_LOG_INFO, "Started by systemd");
+			Log1(PCSC_LOG_INFO, "Started with socket activation");
 		}
 		else
 			SocketActivated = false;
 	}
-#endif
 
 	/*
 	 * test the presence of /var/run/pcscd/pcscd.comm
@@ -720,11 +712,9 @@ int main(int argc, char **argv)
 	/*
 	 * Initialize the comm structure
 	 */
-#ifdef USE_LIBSYSTEMD
 	if (SocketActivated)
-		rv = ListenExistingSocket(SD_LISTEN_FDS_START + 0);
+		rv = ListenExistingSocket(LISTEN_FDS_START + 0);
 	else
-#endif
 		rv = InitializeSocket();
 
 	if (rv)

--- a/src/utils.h
+++ b/src/utils.h
@@ -57,6 +57,9 @@ int CheckForOpenCT(void);
 int ThreadCreate(pthread_t *, int, PCSCLITE_THREAD_FUNCTION( ),
 	/*@null@*/ LPVOID);
 
+#define LISTEN_FDS_START 3
+int GetListenFdCount(void);
+
 #endif
 
 #endif


### PR DESCRIPTION
I've been wanting to implement this for over a year and haven't really finished my original patching attempt. But given recent events (the xz and libsystemd + sshd fiasco) I have decided to give it another go.

I am under no impression that the changes should be included as is, as I've made little to no effort to familiarise myself with the project's coding style and other aspects. But before I commit any more time to this, I wanted to ask for comments to see if this change would even be appealing.

For some background: I am a fan of non-conventional service management and have been working on my own system management suite for some time. I think that socket activation as a concept is quite cool and is not unique to systemd. Unfortunately, a bunch of services which support it, do so by depending on libsystemd which is not often shipped by distributions which do not utilise systemd.

As such, I propose that the dependency on libsystemd is dropped in favour of a simple implementation of the systemd socket activation protocol.

The patch, as it currently stands, tries to match exactly the features which were previously offered by `sd_listen_fds` and `sd_is_socket`. Although I've taken some liberties to increase the verbosity of the logging in the latter case.

While inevitably in my time dealing with service management I've perused the systemd sources, I didn't re-implement any of this from memory and instead relied solely on the libsystemd man pages and my own knowledge of how to implement these features. So I don't believe there's any copyright issue here. 