### PR TITLE
Ensure cleanup on hotplug_libusb shutdown

### DIFF
--- a/src/hotplug_libusb.c
+++ b/src/hotplug_libusb.c
@@ -447,30 +447,6 @@ static void HPRescanUsbBus(void)
 
 	/* free the libusb allocated list & devices */
 	libusb_free_device_list(devs, 1);
-
-	if (AraKiriHotPlug)
-	{
-		int retval;
-
-		for (i=0; i<PCSCLITE_MAX_READERS_CONTEXTS; i++)
-		{
-			if (readerTracker[i].fullName != NULL)
-				HPCleanupHotPluggable(i);
-		}
-
-		for (i=0; i<driverSize; i++)
-		{
-			/* free strings allocated by strdup() */
-			free(driverTracker[i].bundleName);
-			free(driverTracker[i].libraryPath);
-			free(driverTracker[i].readerName);
-			free(driverTracker[i].CFBundleName);
-		}
-		free(driverTracker);
-
-		Log1(PCSC_LOG_INFO, "Hotplug stopped");
-		pthread_exit(&retval);
-	}
 }
 
 static void * HPEstablishUSBNotifications(int pipefd[2])
@@ -526,7 +502,6 @@ static void * HPEstablishUSBNotifications(int pipefd[2])
 			SYS_Sleep(HPForceReaderPolling);
 			HPRescanUsbBus();
 		}
-		libusb_exit(ctx);
 	}
 	else
 	{
@@ -549,6 +524,29 @@ static void * HPEstablishUSBNotifications(int pipefd[2])
 		close(rescan_pipe[0]);
 		rescan_pipe[0] = -1;
 	}
+
+	libusb_exit(ctx);
+
+	for (int i=0; i<PCSCLITE_MAX_READERS_CONTEXTS; i++)
+	{
+		if (readerTracker[i].fullName != NULL)
+			HPCleanupHotPluggable(i);
+	}
+
+	for (int i=0; i<driverSize; i++)
+	{
+		/* free strings allocated by strdup() */
+		free(driverTracker[i].bundleName);
+		free(driverTracker[i].libraryPath);
+		free(driverTracker[i].readerName);
+		free(driverTracker[i].CFBundleName);
+	}
+	free(driverTracker);
+
+	close(rescan_pipe[0]);
+	rescan_pipe[0] = -1;
+
+	Log1(PCSC_LOG_INFO, "Hotplug stopped");
 
 	return NULL;
 }


### PR DESCRIPTION
Make sure the hotplug_libusb cleanup code is executed on all exit
branches from the thread. This prevents memory and resource leaks
on these codepaths.

Before the commit, it was possible that the cleanup code in
HPRescanUsbBus() would be skipped if the caller
(HPEstablishUSBNotifications()) decides to exit on its own. Also
libusb_exit() was skipped in some branches.

The commit moves the cleanup code to the end of
HPEstablishUSBNotifications() and removes pthread_exit() from
HPRescanUsbBus(), so that cleanup isn't skipped.