### PR TITLE
Changes to make it compilable in recent Cygwin environment

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,6 +4,7 @@ fix-rights:
 	$(MAKE) -C src $@
 
 ACLOCAL_AMFLAGS = -I m4
+AM_LIBTOOLFLAGS = -no-undefined
 
 DISTCHECK_CONFIGURE_FLAGS = \
 	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,10 @@ AS_CASE(["$host"],
 		IOKIT="-Wl,-framework,IOKit"
 		AS_IF([test "$GCC" = "yes"], [CFLAGS="$CFLAGS -no-cpp-precomp"])
 		use_libusb=no
-		AC_MSG_WARN([libusb disabled on Darwin for pcsc-lite])]
+		AC_MSG_WARN([libusb disabled on Darwin for pcsc-lite])],
+        [*-*-cygwin*], [
+                CPPFLAGS="$CPPFLAGS -I/usr/include"
+                LDFLAGS="$LDFLAGS -L/usr/lib"]
 )
 
 # Options

--- a/src/PCSC/ifdhandler.h
+++ b/src/PCSC/ifdhandler.h
@@ -251,7 +251,7 @@ whichever location your reader resides.
 #ifndef _ifd_handler_h_
 #define _ifd_handler_h_
 
-#include <pcsclite.h>
+#include "pcsclite.h"
 
 	/*
 	 * List of data structures available to ifdhandler

--- a/src/PCSC/pcsclite.h.in
+++ b/src/PCSC/pcsclite.h.in
@@ -42,7 +42,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __pcsclite_h__
 #define __pcsclite_h__
 
-#include <wintypes.h>
+#include "wintypes.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/src/PCSC/wintypes.h
+++ b/src/PCSC/wintypes.h
@@ -74,6 +74,10 @@ extern "C"
 
 #else
 
+#ifdef __CYGWIN__
+#include <_mingw.h>
+#endif
+
 #ifndef BYTE
 	typedef unsigned char BYTE;
 #endif
@@ -82,14 +86,26 @@ extern "C"
 	typedef unsigned short USHORT;
 
 #ifndef __COREFOUNDATION_CFPLUGINCOM__
-	typedef unsigned long ULONG;
+#ifndef __CYGWIN__
+        typedef unsigned long ULONG;
+#else
+        typedef unsigned __LONG32 ULONG;
+#endif
 	typedef void *LPVOID;
 #endif
 
 	typedef const void *LPCVOID;
-	typedef unsigned long DWORD;
+#ifndef __CYGWIN__
+        typedef unsigned long DWORD;
+#else
+        typedef unsigned __LONG32 DWORD;
+#endif
 	typedef DWORD *PDWORD;
-	typedef long LONG;
+#ifndef __CYGWIN__
+        typedef long LONG;
+#else
+        typedef __LONG32 LONG;
+#endif
 	typedef const char *LPCSTR;
 	typedef const BYTE *LPCBYTE;
 	typedef BYTE *LPBYTE;
@@ -102,7 +118,11 @@ extern "C"
 	typedef LPCSTR LPCTSTR;
 
 	/* types unused by pcsc-lite */
-	typedef short BOOL;
+#ifndef __CYGWIN__
+        typedef short BOOL;
+#else
+        typedef int BOOL;
+#endif
 	typedef unsigned short WORD;
 	typedef ULONG *PULONG;
 

--- a/src/eventhandler.h
+++ b/src/eventhandler.h
@@ -41,9 +41,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdint.h>
 
-#include "pcsclite.h"
+#include "PCSC/pcsclite.h"
 #include "readerfactory.h"
-#include "wintypes.h"
+#include "PCSC/wintypes.h"
 
 	/**
 	 * Define an exported public reader state structure so each

--- a/src/readerfactory.h
+++ b/src/readerfactory.h
@@ -41,7 +41,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <inttypes.h>
 #include <pthread.h>
 
-#include "ifdhandler.h"
+#include "PCSC/ifdhandler.h"
 #include "pcscd.h"
 #include "simclist.h"
 

--- a/src/winscard_msg.h
+++ b/src/winscard_msg.h
@@ -43,8 +43,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdint.h>
 
-#include "pcsclite.h"
-#include "wintypes.h"
+#include "PCSC/pcsclite.h"
+#include "PCSC/wintypes.h"
 
 /** Major version of the current message protocol */
 #define PROTOCOL_VERSION_MAJOR 4


### PR DESCRIPTION
Fixed path errors to get the header chain working correctly.
Additionally added required seperation for Cygwin environment to wintypes header