### PR TITLE
make building work again when flex is not installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,10 @@ AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_LEX([noyywrap])
-AS_IF([test $LEX = ":"], [AC_MSG_ERROR([no lex or flex found])])
+AS_IF([test $LEX = ":"], [
+       AM_MISSING_PROG(MISSINGLEX, [flex])
+       LEX=$MISSINGLEX]
+)
 PKG_PROG_PKG_CONFIG
 AM_PROG_CC_C_O
 AM_PROG_AR
@@ -281,7 +284,7 @@ AS_IF([test "$use_polkit" != "no"],
 		 PCSCLITE_FEATURES="${PCSCLITE_FEATURES} polkit"],
 		[use_polkit=no
 		 AC_MSG_ERROR([[
-*** 
+***
 *** polkit >= $POLKIT_MINIMUM was not found. Access control will be disabled.
 *** You may get it from http://www.freedesktop.org/software/polkit/
 *** ]])
@@ -440,4 +443,3 @@ src/PCSC/pcsclite.h
 src/spy/Makefile
 ])
 AC_OUTPUT
-


### PR DESCRIPTION
This explicitly reverts commit 3f89340785934785cf1490d3e788eefb25c50a69 because it was a bad idea.

The motivating bug report was https://github.com/LudovicRousseau/PCSC/issues/124 and the issue there occurred when building from a git clone, running ./bootstrap && ./configure && make, and having:

- configure succeed
- make "succeeeds" at having $LEX run, do nothing and fail to generate required sources
- compiling nonexistent files fail with highly confusing errors

The autoconf manual has always documented the correct way to handle this is to check if lex is unavailable, and set it to the famous automake wrapper "missing", which checks if a program is missing at build time rather than at ./configure time, and fails the build if the rule cannot be run. This means:

When building from a git clone, if flex is not available then
- configure succeeds
- make fails to run $LEX, and tells you to install flex

The previous attempt to fix the highly confusing error instead resulted in configure erroring out, and saying flex is required, even when it is *not* required because a `make dist` tarball was used, which contains pregenerated tokenparser.c for the express purpose of making flex unnecessary.

See autoconf documentation on $LEX:
https://www.gnu.org/software/autoconf/manual/autoconf-2.72/html_node/Particular-Programs.html#index-AC_005fPROG_005fLEX-1

And automake documentation on why to use "missing": https://www.gnu.org/software/automake/manual/html_node/maintainer_002dmode.html