### PR TITLE
pcsc-lite: fix formats under musl

### DIFF
--- a/src/debuglog.c
+++ b/src/debuglog.c
@@ -262,7 +262,7 @@ static void log_line(const int priority, const char *DebugBuffer,
 					break;
 			}
 
-#ifdef __APPLE__
+#ifndef __GLIBC__
 #define THREAD_FORMAT "%p"
 #else
 #define THREAD_FORMAT "%lu"

--- a/src/spy/libpcscspy.c
+++ b/src/spy/libpcscspy.c
@@ -121,7 +121,7 @@ static void spy_line_direct(char *line)
 	if (Log_fd < 0)
 		return;
 
-	snprintf(threadid, sizeof threadid, "%lX@", pthread_self());
+	snprintf(threadid, sizeof threadid, "%lX@", (unsigned long)pthread_self());
 	pthread_mutex_lock(&Log_fd_mutex);
 	r = write(Log_fd, threadid, strlen(threadid));
 	r = write(Log_fd, line, strlen(line));
@@ -150,7 +150,7 @@ static void spy_line(const char *fmt, ...)
 		printf("libpcsc-spy: Buffer is too small!\n");
 		return;
 	}
-	snprintf(threadid, sizeof threadid, "%lX@", pthread_self());
+	snprintf(threadid, sizeof threadid, "%lX@", (unsigned long)pthread_self());
 	pthread_mutex_lock(&Log_fd_mutex);
 	r = write(Log_fd, threadid, strlen(threadid));
 	r = write(Log_fd, line, size);


### PR DESCRIPTION
pthread_t is a pointer.