### PR TITLE
Fix using dlopen on OpenBSD

### DIFF
--- a/src/libredirect.c
+++ b/src/libredirect.c
@@ -127,7 +127,11 @@ static void log_line(const char *fmt, ...)
 
 static LONG load_lib(void)
 {
+#ifdef __OpenBSD__
+#define LIBPCSC "libpcsclite_real.so"
+#else
 #define LIBPCSC "libpcsclite_real.so.1"
+#endif
 
 	const char *lib;
 

--- a/src/spy/libpcscspy.c
+++ b/src/spy/libpcscspy.c
@@ -286,7 +286,11 @@ static void spy_readerstate(SCARD_READERSTATE * rgReaderStates, int cReaders)
 static LONG load_lib(void)
 {
 
+#ifdef __OpenBSD__
+#define LIBPCSC "libpcsclite_real.so"
+#else
 #define LIBPCSC "libpcsclite_real.so.1"
+#endif
 
 	const char *lib;
 


### PR DESCRIPTION
libraries dlopen'd on OpenBSD need to have the major version
left off.