### PR TITLE
Implement IsClientAuthorized() for FreeBSD and stop failing open

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -159,6 +159,10 @@ cleanup1:
 	return ret;
 }
 
+#elif defined(HAVE_POLKIT)
+
+#error polkit is enabled, but no socket cred implementation for this platform
+
 #else
 
 unsigned IsClientAuthorized(int socket, const char* action, const char* reader)


### PR DESCRIPTION
We can provide a sensible polkit implementation on FreeBSD with our analog to SO_PEERCRED, so do it.  The functionality is identical modulo some naming differences in the xucred that we get back.

While we're here, don't fail open if polkit was specifically requested.  AFAICT the meson build won't enable it without an explicit -Dpolkit=true, so if we got to auth.c with HAVE_POLKIT then the build requested it.  Failing open (i.e. not consulting the policy) results in a daemon that behaves quite surprisingly when the user expected it to be consulting polkit before granting access.  Considering the nature of the daemon, this seems like a safer/better default.