### PR TITLE
Assign default value to PCSCD_ARGS

### DIFF
--- a/etc/pcscd.service.in
+++ b/etc/pcscd.service.in
@@ -6,6 +6,7 @@ Documentation=man:pcscd(8)
 [Service]
 ExecStart=@sbindir_exp@/pcscd --foreground --auto-exit $PCSCD_ARGS
 ExecReload=@sbindir_exp@/pcscd --hotplug
+Environment=PCSCD_ARGS=
 EnvironmentFile=-@sysconfdir@/default/pcscd
 
 [Install]


### PR DESCRIPTION
According to systemd.exec(5), a value in EnvironmentFile, as used now, overrides this setting.

Newer systemd will otherwise produce the following warning: "pcscd.service: Referenced but unset environment variable evaluates to an empty string: PCSCD_ARGS".