### PR TITLE
Fix libpcsclite.pc fiel generated by Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -308,6 +308,7 @@ endif
 # pkg-config libpcsclite.pc
 pkg = import('pkgconfig')
 pkg.generate(
+  extra_cflags : '-pthread',
   libraries : '-L${libdir} -lpcsclite',
   libraries_private : '-pthread',
   subdirs : 'PCSC',


### PR DESCRIPTION
Running `pkgconf --libs --cflags` does not include `-pthread` without this change. It also matches what the autotools build generates.

The issue was brought up in FreeBSD Ports: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=285857#c3