### PR TITLE
meson: respect builtin meson default_library option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -186,24 +186,31 @@ libpcsclite_src = [
   'src/libredirect.c',
   'src/sys_unix.c'
   ]
-libpcsclite = shared_library('pcsclite',
-  libpcsclite_src,
-  dependencies : dl_deps,
-  include_directories : incdir,
-  soversion : 1,
-  install : true)
+if get_option('default_library') != 'static'
+  libpcsclite = shared_library('pcsclite',
+    libpcsclite_src,
+    dependencies : dl_deps,
+    include_directories : incdir,
+    soversion : 1,
+    install : true)
+endif
 
 # static library
 libpcsclite_static_src = libpcsclite_real_src + [
   'src/error.c',
   'src/g_defines.c',
   ]
-libpcsclite_static = static_library('pcsclite',
-  libpcsclite_static_src,
-  include_directories : incdir,
-  dependencies : threads_dep,
-  c_args: '-DLIBPCSCLITE -DSIMCLIST_NO_DUMPRESTORE',
-  install : true)
+if get_option('default_library') != 'shared'
+  libpcsclite_static = static_library('pcsclite',
+    libpcsclite_static_src,
+    include_directories : incdir,
+    dependencies : threads_dep,
+    c_args: '-DLIBPCSCLITE -DSIMCLIST_NO_DUMPRESTORE',
+    install : true)
+  if get_option('default_library') == 'static'
+    libpcsclite = libpcsclite_static
+  endif
+endif
 
 # libpcsclite_fake library
 library('pcsclite_fake',
@@ -241,10 +248,12 @@ executable('pcsc_demo',
   include_directories : incdir,
   link_with : libpcsclite)
 
-executable('pcsc_demo_static',
-  sources : 'doc/example/pcsc_demo.c',
-  include_directories : incdir,
-  link_with : libpcsclite_static)
+if get_option('default_library') == 'both'
+  executable('pcsc_demo_static',
+    sources : 'doc/example/pcsc_demo.c',
+    include_directories : incdir,
+    link_with : libpcsclite_static)
+endif
 
 # PC/SC headers
 install_headers(


### PR DESCRIPTION
pcsclite can be built both statically or shared. It has to be built differently to support static usage due to the delegate mechanism. In order to handle this, separate calls are made to static_library() and shared_library(), which sidestep meson's usual handling for selecting the correct requested build variant.

Solve this by looking up the builtin option and choosing whether or not to build each library. This means people intending to only ship the shared library, no longer spend time compiling the static one -- nor have to manually delete it after it is installed by `meson install`.

Fixes a stray static library appearing on Gentoo (which builds with default_library=shared).

Ref: https://github.com/LudovicRousseau/PCSC/issues/216