### PR TITLE
fix build when linking against glibc < 2.34

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -182,7 +182,7 @@ libpcsclite_src = [
 if get_option('default_library') != 'static'
   libpcsclite = shared_library('pcsclite',
     libpcsclite_src,
-    dependencies : dl_deps,
+    dependencies : [dl_deps, threads_dep],
     include_directories : incdir,
     soversion : 1,
     install : true)
@@ -198,7 +198,7 @@ if get_option('default_library') != 'static'
   # libpcscspy library
   library('pcscspy',
     sources : ['src/spy/libpcscspy.c', 'src/sys_unix.c'],
-    dependencies : dl_deps,
+    dependencies : [dl_deps, threads_dep],
     include_directories : incdir,
     soversion : 0,
     install : true)


### PR DESCRIPTION
Since efe24581d442a29c82ad0355b2f8e5212a5c15f8 and f0f4fa1586f1cc695ad42c88d19dc4f15bfa3c71, pcscspy and libpcsclite depends on pthreads.

On systems with glibc >=2.34, the change was not needed, but for older systems it won't build.