### PR TITLE
systemd Fails to parse boolean value.

### DIFF
--- a/etc/pcscd.service.in
+++ b/etc/pcscd.service.in
@@ -10,7 +10,7 @@ ExecReload=@sbindir_exp@/pcscd --hotplug
 EnvironmentFile=-@sysconfdir@/default/pcscd
 User=pcscd
 RuntimeDirectory=pcscd
-RuntimeDirectoryPreserve=true
+RuntimeDirectoryPreserve=yes
 PIDFile=@ipcdir@/pcscd.pid
 
 # Paths


### PR DESCRIPTION
My host is installed with a Rocky Linux 9.x
It should be the same with other distros.

When PCSC is started, I can observe the following in /var/log/messages:
```
...
Dec 05 16:22:43 Host-9A38CE systemd[1]: /usr/lib/systemd/system/pcscd.service:32: Failed to parse boolean value, ignoring: identity
                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
```

This comes from the following line, in pcscd.service:
```
RuntimeDirectoryPreserve=true
```

When `true` is replaced by `yes`, the error is no more seen. By the way, the rest of pcscd.service is already using `yes`.