### PR TITLE
meson: Add force_systemdunit option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -127,11 +127,19 @@ if get_option('polkit')
   features += 'polkit'
 endif
 
+systemdunit = get_option('systemdunit')
 if get_option('libsystemd')
   systemd_dep = dependency('libsystemd')
   pcscd_dep += systemd_dep
   conf_data.set('USE_LIBSYSTEMD', true)
   features += 'systemd'
+
+  systemd = dependency('systemd')
+  systemdsystemunitdir = systemd.get_variable(pkgconfig : 'systemd' + systemdunit + 'unitdir')
+  sysusersdir = systemd.get_variable(pkgconfig : 'sysusersdir')
+else
+  systemdsystemunitdir = get_option('prefix') / 'lib' / 'systemd' / systemdunit
+  sysusersdir = get_option('prefix') / 'sysusers.d'
 endif
 
 # architecture
@@ -291,11 +299,6 @@ configure_file(output : 'pcsclite.h',
 configure_file(output : 'pcscd.h',
   input : 'src/pcscd.h.in',
   configuration : confgen_data)
-if get_option('libsystemd')
-  systemd = dependency('systemd')
-  unit = get_option('systemdunit')
-  systemdsystemunitdir = systemd.get_variable(pkgconfig : 'systemd' + unit + 'unitdir')
-  sysusersdir = systemd.get_variable(pkgconfig : 'sysusersdir')
 configure_file(output : 'pcscd.socket',
   input : 'etc/pcscd.socket.in',
   install_dir : systemdsystemunitdir,
@@ -306,7 +309,6 @@ configure_file(output : 'pcscd.service',
   configuration : confgen_data)
 install_data('etc/pcscd-sysusers.conf',
   install_dir : sysusersdir)
-endif
 configure_file(output : 'pcscd.8',
   input : 'doc/pcscd.8.in',
   install_dir : join_paths(get_option('mandir'), 'man8'),


### PR DESCRIPTION
Allows installation of systemd services without libsystemd installed. Usefull for Alpine Linux where systemd services are allowed to be subpackaged (e.g. for postmarketOS) but hasn't systemd in it's repos.

A another popular alternative in meson build systems is to use a custom systemdunitdir/sysusersdir per option and use that if it's specified, instead of hardcoding the directories if systemd is not found. I would also implement that if that is wished.