### PR TITLE
pcscd.socket.in: drop the devilish 0666  socket mode

### DIFF
--- a/etc/pcscd.socket.in
+++ b/etc/pcscd.socket.in
@@ -3,7 +3,7 @@ Description=PC/SC Smart Card Daemon Activation Socket
 
 [Socket]
 ListenStream=@ipcdir@/pcscd.comm
-SocketMode=0666
+SocketMode=0660
 SocketUser=pcscd
 SocketGroup=pcscd
 


### PR DESCRIPTION
`0666` happily welcomed every process on the system with open arms blessed with the number of the beast itself.

Restrict access to the `pcscd` group so only the chosen few may speak to the daemon.