### PR TITLE
Bump the version in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.69])
 
-AC_INIT([pcsc-lite], [2.2.0])
+AC_INIT([pcsc-lite], [2.4.1])
 AC_CONFIG_SRCDIR(src/pcscdaemon.c)
 AM_INIT_AUTOMAKE(1.8 dist-bzip2 no-dist-gzip foreign subdir-objects)
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
Since make is still supported to compile the repository, we should also update the version in configure.ac to the latest release version.