### PR TITLE
Create separate local-build job in .yml

### DIFF
--- a/.github/workflows/build_meson.yml
+++ b/.github/workflows/build_meson.yml
@@ -21,7 +21,7 @@ jobs:
         shell: bash
         run: |
           sudo apt update
-          sudo apt install \
+          sudo apt install -y \
             autoconf-archive \
             debhelper-compat \
             doxygen \

--- a/.github/workflows/build_meson.yml
+++ b/.github/workflows/build_meson.yml
@@ -7,8 +7,58 @@ on: [push, pull_request]
 # A workflow run is made up of one or more jobs that can run
 # sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+  # This workflow contains a job called "build" for CI builds
   build:
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job
+      # can access it
+      - uses: actions/checkout@v7
+
+      - name: setup prerequisites
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install \
+            autoconf-archive \
+            debhelper-compat \
+            doxygen \
+            dpkg-dev \
+            flex \
+            libpolkit-gobject-1-dev \
+            libsystemd-dev \
+            libudev-dev \
+            libusb-1.0-0-dev \
+            meson \
+            pkg-config
+
+      - name: compile
+        shell: bash
+        run: |
+          export CFLAGS="-Wall -Wextra -Wformat -Wformat-security -Wmissing-declarations -Wmissing-prototypes -Wold-style-definition -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wswitch-enum -Wundef -Wuninitialized -Wunused -Wwrite-strings -Wmissing-noreturn -flto=auto -O2"
+          meson setup builddir --werror
+          cd builddir
+
+          DESTDIR=/tmp/pcsc meson install
+          find /tmp/pcsc
+
+          meson dist
+
+          # doxygen
+          meson compile doc
+
+          meson setup --reconfigure -Dlibsystemd=false -Dlibudev=false -Dpolkit=false
+          meson compile
+
+          meson setup --reconfigure -Dserial=true
+          meson compile
+
+          meson setup --reconfigure -Dembedded=true
+          meson compile
+
+  local-build:
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -44,7 +94,7 @@ jobs:
           DESTDIR=/tmp/pcsc meson install
           find /tmp/pcsc
 
-          meson dist
+          meson dist --allow-dirty
 
           # doxygen
           meson compile doc

--- a/.github/workflows/build_meson.yml
+++ b/.github/workflows/build_meson.yml
@@ -61,10 +61,7 @@ jobs:
   local-build:
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job
-      # can access it
       - uses: actions/checkout@v7
 
       - name: setup prerequisites
@@ -91,8 +88,9 @@ jobs:
           meson setup builddir --werror
           cd builddir
 
-          DESTDIR=/tmp/pcsc meson install
-          find /tmp/pcsc
+          # Use ../dist to write to repo root outside builddir
+          DESTDIR=../dist meson install
+          find ../dist
 
           meson dist --allow-dirty
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,75 @@ PCSC lite project
 Middleware to access a smart card using SCard API (PC/SC)
 ---------------------------------------------------------
 
+To compile locally inside of a container use (`act` needs to be installed on your system):
+
+```sh
+$ act -b -W .github/workflows/build_meson.yml -j local-build
+```
+
+once done, built libs are inside of `dist/`. To install those use following on host machine:
+
+```sh
+# 1. Copy staged build files to host root and update library cache
+sudo cp -av dist/* /
+sudo ldconfig
+
+# 2. Setup systemd unit files, system user, and reload daemon
+sudo cp /usr/lib/systemd/user/pcscd.* /lib/systemd/system/
+sudo systemd-sysusers
+sudo systemctl daemon-reload
+
+# 3. Enable and start the systemd socket
+sudo systemctl reset-failed pcscd.socket
+sudo systemctl enable --now pcscd.socket
+
+# 4. Install standard CCID drivers and testing tools
+sudo apt update
+sudo apt install -y pcsc-tools libccid
+
+# 5. Restart daemon and test smart card reader detection
+sudo systemctl restart pcscd
+pcsc_scan
+```
+
+and to check the installation:
+
+```sh
+pcscd --version
+```
+
+Uninstall:
+
+```sh
+# 1. Stop and disable active systemd units
+sudo systemctl disable --now pcscd.service pcscd.socket
+
+# 2. Remove systemd unit files & sysusers config
+sudo rm -f /lib/systemd/system/pcscd.service /lib/systemd/system/pcscd.socket
+sudo rm -f /usr/lib/systemd/user/pcscd.service /usr/lib/systemd/user/pcscd.socket
+sudo rm -f /usr/lib/sysusers.d/pcscd-sysusers.conf
+sudo systemctl daemon-reload
+
+# 3. Remove binaries, headers, libraries, and configurations
+sudo rm -f /usr/local/sbin/pcscd
+sudo rm -f /usr/local/bin/pcsc-spy
+sudo rm -rf /usr/local/include/PCSC
+sudo rm -f /usr/local/lib/x86_64-linux-gnu/libpcsclite.so*
+sudo rm -f /usr/local/lib/x86_64-linux-gnu/libpcsclite_real.so*
+sudo rm -f /usr/local/lib/x86_64-linux-gnu/libpcscspy.so*
+sudo rm -f /usr/local/lib/x86_64-linux-gnu/pkgconfig/libpcsclite.pc
+sudo rm -f /usr/local/etc/default/pcscd
+sudo rm -f /usr/local/share/metainfo/fr.apdu.pcsclite.metainfo.xml
+sudo rm -f /usr/local/share/man/man5/reader.conf.5
+sudo rm -f /usr/local/share/man/man1/pcsc-spy.1
+sudo rm -f /usr/local/share/man/man8/pcscd.8
+sudo rm -rf /usr/local/share/doc/pcsc-lite
+sudo rm -f /usr/share/polkit-1/actions/org.debian.pcsc-lite.policy
+
+# 4. Update system dynamic library cache
+sudo ldconfig
+```
+
 The project Web site is: https://pcsclite.apdu.fr/
 
 <a href="https://codeclimate.com/github/LudovicRousseau/PCSC"><img src="https://codeclimate.com/github/LudovicRousseau/PCSC/badges/gpa.svg" /></a>


### PR DESCRIPTION
- Add -y to sudo apt install. Otherwise local build using `act` (reusing .yml) will be stuck on `sudo apt install`
- Add `--allow-dirty` otherwise local build fails with:
`| ERROR: Repository has uncommitted changes that will not be included in the dist tarball
| Use --allow-dirty to ignore the warning and proceed anyway
[build_meson/build]   ❌  Failure - Main compile [4.803713372s]
[build_meson/build] exitcode '1': failure
[build_meson/build] ⭐ Run Complete job
[build_meson/build] unable to get git ref: failed to identify reference (tag/branch) for the checked-out revision '4966d71de418d3ad31e6903fd36d12490956beea'
[build_meson/build]   ✅  Success - Complete job
[build_meson/build] 🏁  Job failed
Error: Job 'build' failed
`
